### PR TITLE
Makes a totally separate docker build

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build and run",
+            "type": "shell",
+            "command": "./scripts/build.bat",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:1.76
+WORKDIR /usr/src/lies
+COPY . .
+RUN cargo install --path .
+ENV LIES_PARSE_LOG_MODE=FILE
+EXPOSE 80
+COPY scripts/start.sh start.sh
+RUN chmod +x start.sh
+CMD ["./start.sh"]

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -1,0 +1,32 @@
+@echo off
+
+if not exist .env (
+    echo .env file does not exist.
+    exit /b 1
+)
+
+for /f "delims== tokens=1,2" %%a in ('findstr /b GAME_DIR .env') do (
+    if "%%a"=="GAME_DIR" (
+        set GAME_DIR=%%b
+    )
+)
+
+if not defined GAME_DIR (
+    echo GAME_DIR is not set
+    exit /b 1
+)
+
+
+echo Building docker image with volume directory: %GAME_DIR%
+docker build -q -t lies .
+
+docker ps -a --filter "name=LiES" | findstr /v "CONTAINER ID" >nul
+if errorlevel 1 (
+    echo Starting docker...
+    docker run --tty --name LiES -e GAME_DIR=/usr/src/ss13 -v %GAME_DIR%:/usr/src/ss13 -p 4000:80 lies
+) else (
+    echo Restarting docker...
+    docker restart LiES >nul
+    echo Running LiES...
+    docker exec LiES /bin/sh -c "./start.sh"
+)

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -1,32 +1,3 @@
 @echo off
-
-if not exist .env (
-    echo .env file does not exist.
-    exit /b 1
-)
-
-for /f "delims== tokens=1,2" %%a in ('findstr /b GAME_DIR .env') do (
-    if "%%a"=="GAME_DIR" (
-        set GAME_DIR=%%b
-    )
-)
-
-if not defined GAME_DIR (
-    echo GAME_DIR is not set
-    exit /b 1
-)
-
-
-echo Building docker image with volume directory: %GAME_DIR%
-docker build -q -t lies .
-
-docker ps -a --filter "name=LiES" | findstr /v "CONTAINER ID" >nul
-if errorlevel 1 (
-    echo Starting docker...
-    docker run --tty --name LiES -e GAME_DIR=/usr/src/ss13 -v %GAME_DIR%:/usr/src/ss13 -p 4000:80 lies
-) else (
-    echo Restarting docker...
-    docker restart LiES >nul
-    echo Running LiES...
-    docker exec LiES /bin/sh -c "./start.sh"
-)
+@REM All this just to change colors in terminal
+powershell -ExecutionPolicy Bypass -File .\scripts\build.ps1

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,31 @@
+if (!(Test-Path .env)) {
+    Write-Host ".env file does not exist." -ForegroundColor Red
+    exit 1
+}
+
+$env:GAME_DIR = (Get-Content .env | Where-Object { $_ -match 'GAME_DIR' } | ForEach-Object { $($_ -split '=')[1] })
+
+if (!$env:GAME_DIR) {
+    Write-Host "GAME_DIR is not set" -ForegroundColor Red
+    exit 1
+}
+
+docker image inspect lies >$null 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Building docker image with volume directory: " -NoNewline -ForegroundColor Blue
+    Write-Host "$env:GAME_DIR"
+    docker build -q -t lies .
+} else {
+    Write-Host "Valid docker image found." -ForegroundColor Blue
+}
+
+docker ps -a --filter "name=LiES" | Select-String -NotMatch "CONTAINER ID" >$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Starting docker..." -ForegroundColor Blue
+    docker run --tty --name LiES -e GAME_DIR=/usr/src/ss13 -v $env:GAME_DIR:/usr/src/ss13 -p 4000:80 lies
+} else {
+    Write-Host "Restarting docker..." -ForegroundColor Blue
+    docker restart LiES >$null
+    Write-Host "Running LiES..." -ForegroundColor Blue
+    docker exec --tty LiES /bin/sh -c "./start.sh"
+}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+cargo run || exit 1

--- a/src/dm_parser/lib.rs
+++ b/src/dm_parser/lib.rs
@@ -80,9 +80,24 @@ impl DmParser {
         let load_from = self
             .environment_directory
             .join(self.preprocessor.get_base_file_dir());
-        let wanted_path = load_from
-            .join(current_traversal)
-            .join(wanted_path)
+        let wanted_path = load_from.join(current_traversal).join(wanted_path);
+
+        let wanted_path_str = wanted_path.to_str().unwrap();
+        // Unix / docker fix
+        let wanted_path_str_fixed = if cfg!(unix) {
+            wanted_path_str.replace('\\', "/")
+        } else {
+            wanted_path_str.to_string()
+        };
+        let wanted_path = PathBuf::from(wanted_path_str_fixed);
+
+        if !wanted_path.exists() {
+            return Err(format!(
+                "File or directory does not exist: {}",
+                wanted_path.display()
+            ));
+        }
+        let wanted_path = wanted_path
             .canonicalize()
             .expect("failed to canonicalize wanted path");
 

--- a/src/dm_preprocessor/directive/define.rs
+++ b/src/dm_preprocessor/directive/define.rs
@@ -1,4 +1,5 @@
-use log::error;
+#[warn(unused_imports)]
+use log::{error, warn};
 
 use crate::{
     dm_preprocessor::{define_definition::DmDefineDefinition, lib::DmPreProcessor},

--- a/src/dm_preprocessor/lib.rs
+++ b/src/dm_preprocessor/lib.rs
@@ -171,8 +171,8 @@ impl DmPreProcessor {
             }
         }
 
-        #[cfg(not(debug_assertions))]
-        warn!("macros are not yet implemented, '{macro_definition:#?}' args {args:#?}");
+        // #[cfg(not(debug_assertions))]
+        // warn!("macros are not yet implemented, '{macro_definition:#?}' args {args:#?}");
         None
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,12 @@
 use dm_parser::lib::DmParser;
 use dotenv::dotenv;
 use log::info;
+use std::env;
 
 pub mod dm_parser;
 pub mod dm_preprocessor;
 pub mod tokens;
 pub mod util;
-
-const WORK_DIR: &str = "D:/ss13/tgstation";
 
 pub fn main() -> Result<(), String> {
     dotenv().ok();
@@ -18,7 +17,9 @@ pub fn main() -> Result<(), String> {
 
     let mut stopwatch = stopwatch::Stopwatch::start_new();
 
-    let mut parser = DmParser::new(WORK_DIR);
+    let game_dir = env::var("GAME_DIR").unwrap();
+
+    let mut parser = DmParser::new(game_dir);
     parser.load("tgstation.dme")?;
 
     stopwatch.stop();


### PR DESCRIPTION
You can now run and build LiES on any OS without even having rust installed. You can still run it normally via `cargo run`.

Just <kbd>CTRL</kbd><kbd>Shift</kbd><kbd>B</kbd>

It runs significantly faster (64.71%) than the normal LiES. Don't know!

# NOTE
With this, you must have GAME_DIR set in .env file to your local ss13 repo. Which, should have been the case anyways, as this was hardcoded